### PR TITLE
GridSearch - returning additional value of type list for runs

### DIFF
--- a/bettermdptools/utils/grid_search.py
+++ b/bettermdptools/utils/grid_search.py
@@ -11,6 +11,7 @@ class GridSearch:
     def q_learning_grid_search(env, gamma, epsilon_decay, iters, verbose=True):
         highest_avg_reward = -np.inf
         best_params = None
+        rewards_and_params_results = []
 
         for i in itertools.product(gamma, epsilon_decay, iters):
             if verbose:
@@ -19,6 +20,10 @@ class GridSearch:
             Q, V, pi, Q_track, pi_track = RL(env).q_learning(gamma=i[0], epsilon_decay_ratio=i[1], n_episodes=i[2])
             episode_rewards = TestEnv.test_env(env=env, n_iters=100, pi=pi)
             avg_reward = np.mean(episode_rewards)
+            rewards_and_params_results.append({
+                'avg_reward': avg_reward,
+                'params': i
+            })
             if avg_reward > highest_avg_reward:
                 highest_avg_reward = avg_reward
                 best_params = i
@@ -27,12 +32,13 @@ class GridSearch:
                 print("Avg. episode reward: ", avg_reward)
                 print("###################")
 
-        return highest_avg_reward, best_params
+        return rewards_and_params_results, highest_avg_reward, best_params
 
     @staticmethod
     def sarsa_grid_search(env, gamma, epsilon_decay, iters, verbose=True):
         highest_avg_reward = -np.inf
         best_params = None
+        rewards_and_params_results = []
 
         for i in itertools.product(gamma, epsilon_decay, iters):
             if verbose:
@@ -41,6 +47,10 @@ class GridSearch:
             Q, V, pi, Q_track, pi_track = RL(env).sarsa(gamma=i[0], epsilon_decay_ratio=i[1], n_episodes=i[2])
             episode_rewards = TestEnv.test_env(env=env, n_iters=100, pi=pi)
             avg_reward = np.mean(episode_rewards)
+            rewards_and_params_results.append({
+                'avg_reward': avg_reward,
+                'params': i
+            })
             if avg_reward > highest_avg_reward:
                 highest_avg_reward = avg_reward
                 best_params = i
@@ -49,12 +59,13 @@ class GridSearch:
                 print("Avg. episode reward: ", avg_reward)
                 print("###################")
 
-        return highest_avg_reward, best_params
+        return rewards_and_params_results, highest_avg_reward, best_params
 
     @staticmethod
     def pi_grid_search(env, gamma, n_iters, theta, verbose=True):
         highest_avg_reward = -np.inf
         best_params = None
+        rewards_and_params_results = []
 
         for i in itertools.product(gamma, n_iters, theta):
             if verbose:
@@ -63,6 +74,10 @@ class GridSearch:
             V, V_track, pi = Planner(env.P).policy_iteration(gamma=i[0], n_iters=i[1], theta=i[2])
             episode_rewards = TestEnv.test_env(env=env, n_iters=100, pi=pi)
             avg_reward = np.mean(episode_rewards)
+            rewards_and_params_results.append({
+                'avg_reward': avg_reward,
+                'params': i
+            })
             if avg_reward > highest_avg_reward:
                 highest_avg_reward = avg_reward
                 best_params = i
@@ -71,12 +86,13 @@ class GridSearch:
                 print("Avg. episode reward: ", avg_reward)
                 print("###################")
 
-        return highest_avg_reward, best_params
+        return rewards_and_params_results, highest_avg_reward, best_params
 
     @staticmethod
     def vi_grid_search(env, gamma, n_iters, theta, verbose=True):
         highest_avg_reward = -np.inf
         best_params = None
+        rewards_and_params_results = []
 
         for i in itertools.product(gamma, n_iters, theta):
             if verbose:
@@ -85,6 +101,10 @@ class GridSearch:
             V, V_track, pi = Planner(env.P).value_iteration(gamma=i[0], n_iters=i[1], theta=i[2])
             episode_rewards = TestEnv.test_env(env=env, n_iters=100, pi=pi)
             avg_reward = np.mean(episode_rewards)
+            rewards_and_params_results.append({
+                'avg_reward': avg_reward,
+                'params': i
+            })
             if avg_reward > highest_avg_reward:
                 highest_avg_reward = avg_reward
                 best_params = i
@@ -93,4 +113,4 @@ class GridSearch:
                 print("Avg. episode reward: ", avg_reward)
                 print("###################")
 
-        return highest_avg_reward, best_params
+        return rewards_and_params_results, highest_avg_reward, best_params


### PR DESCRIPTION
I've added the results from each run to a list where each index holds a dict with the keys `"avg_reward"` and `"params"`. This list can be used to analyze the effect of params changes against the value of avg_reward

Credit @fidmor89 - Originally implemented return values for GridSearch util. 